### PR TITLE
Stop mergeJar from writing to its input files

### DIFF
--- a/src/main/java/net/fabricmc/stitch/merge/JarMerger.java
+++ b/src/main/java/net/fabricmc/stitch/merge/JarMerger.java
@@ -134,7 +134,7 @@ public class JarMerger implements AutoCloseable {
             Files.copy(entry.path, outPath);
         }
 
-        Files.getFileAttributeView(entry.path, BasicFileAttributeView.class)
+        Files.getFileAttributeView(outPath, BasicFileAttributeView.class)
                 .setTimes(
                         entry.metadata.creationTime(),
                         entry.metadata.lastAccessTime(),


### PR DESCRIPTION
I found this because Bazel runs actions in a sandboxed environment, and sets input files to read-only. This threw an exception, changing this line fixed it.